### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "pygame"
+run = "python main.py"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Tetris
 Tetris is primarily composed of a field of play in which pieces of different geometric forms, called "tetriminos", descend from the top of the field.
+
+[![Run on Repl.it](https://repl.it/badge/github/kite-jegadees/Tetris)](https://repl.it/github/kite-jegadees/Tetris)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@kitejegadees/Tetris).